### PR TITLE
Remove hardcoded credentials from library

### DIFF
--- a/lib/download_album_preferences.py
+++ b/lib/download_album_preferences.py
@@ -22,9 +22,11 @@ class OrpheusAlbumDownloader:
             if config_path.exists():
                 with open(config_path, 'r') as f:
                     config = json.load(f)
-                    username = username or config.get('username', 'rezivor')
-                    password = password or config.get('password', 'Koolca00')
-                    api_key = api_key or config.get('api_key', 'PSTi7lCo1E4Q9IHgYJvVg3zVpBBUOpGEaer0t1l26Eg5bw1J7l88wk2ua1IGs8X8bCFMej8DFA4Kfb/lMzl3TdWIhx7d50KW6oYTcOEw8Ed7gDLcI6+C')
+                    username = username or config.get('username')
+                    password = password or config.get('password')
+                    api_key = api_key or config.get('api_key')
+        if not all([username, password, api_key]):
+            raise ValueError("Missing username, password, or api_key. Please provide via arguments or config file.")
 
         self.username = username
         self.password = password

--- a/lib/download_collage_torrents.py
+++ b/lib/download_collage_torrents.py
@@ -21,7 +21,9 @@ class OrpheusCollageDownloader:
             if config_path.exists():
                 with open(config_path, 'r') as f:
                     config = json.load(f)
-                    api_key = config.get('api_key', 'PSTi7lCo1E4Q9IHgYJvVg3zVpBBUOpGEaer0t1l26Eg5bw1J7l88wk2ua1IGs8X8bCFMej8DFA4Kfb/lMzl3TdWIhx7d50KW6oYTcOEw8Ed7gDLcI6+C')
+                    api_key = config.get('api_key')
+        if not api_key:
+            raise ValueError("Missing API key. Please provide via argument or config file.")
         
         self.api_key = api_key
         self.base_url = "https://orpheus.network"

--- a/lib/find_album_collages.py
+++ b/lib/find_album_collages.py
@@ -22,9 +22,11 @@ class OrpheusAlbumSearcher:
             if config_path.exists():
                 with open(config_path, 'r') as f:
                     config = json.load(f)
-                    username = username or config.get('username', 'rezivor')
-                    password = password or config.get('password', 'Koolca00')
-                    api_key = api_key or config.get('api_key', 'PSTi7lCo1E4Q9IHgYJvVg3zVpBBUOpGEaer0t1l26Eg5bw1J7l88wk2ua1IGs8X8bCFMej8DFA4Kfb/lMzl3TdWIhx7d50KW6oYTcOEw8Ed7gDLcI6+C')
+                    username = username or config.get('username')
+                    password = password or config.get('password')
+                    api_key = api_key or config.get('api_key')
+        if not all([username, password, api_key]):
+            raise ValueError("Missing username, password, or api_key. Please provide via arguments or config file.")
 
         self.username = username
         self.password = password


### PR DESCRIPTION
## Summary
- eliminate hardcoded fallback credentials from album and collage download tools
- enforce explicit configuration by raising errors when credentials are missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b419f108b88325bf719ddebf331003